### PR TITLE
[2022.10.24] 도형 작업 되돌리기 기능 구현

### DIFF
--- a/src/components/Drawing/index.js
+++ b/src/components/Drawing/index.js
@@ -25,7 +25,7 @@ export default function Drawing() {
     let drawing = false;
     let undoStore = [];
     let redoStore = [];
-    let index = -1;
+    let historyIndex = -1;
 
     colorElement.addEventListener(
       "change",
@@ -44,31 +44,31 @@ export default function Drawing() {
     );
 
     const undo = () => {
-      if (index < 0) {
+      if (historyIndex < 0) {
         context.clearRect(0, 0, canvas.width, canvas.height);
         undoStore = [];
-        index = -1;
-      } else if (index === 0) {
+        historyIndex = -1;
+      } else if (historyIndex === 0) {
         window.alert("전부 지우시려면 clear를 눌러주세요!");
       } else {
-        index -= 1;
+        historyIndex -= 1;
         redoStore.unshift(undoStore.pop());
-        context.putImageData(undoStore[index], 0, 0);
+        context.putImageData(undoStore[historyIndex], 0, 0);
       }
     };
 
     const redo = () => {
       if (redoStore.length > 0) {
-        index += 1;
+        historyIndex += 1;
         undoStore.push(redoStore.shift());
-        context.putImageData(undoStore[index], 0, 0);
+        context.putImageData(undoStore[historyIndex], 0, 0);
       }
     };
 
     const clear = () => {
       context.clearRect(0, 0, canvas.width, canvas.height);
       undoStore = [];
-      index = -1;
+      historyIndex = -1;
     };
 
     const drawLine = (startPosition, endPosition, color, width, emit) => {
@@ -137,7 +137,7 @@ export default function Drawing() {
 
       if (event.type !== "mouseout") {
         undoStore.push(context.getImageData(0, 0, canvas.width, canvas.height));
-        index += 1;
+        historyIndex += 1;
       }
     };
 


### PR DESCRIPTION
# Topic
- 그림판 도형 되돌리기 기능 추가

# Detail
- 기존에 작성한 도형을 되돌릴 수 있다.
- 되돌리기 한 도형들도 다시 원상태로 되돌릴 수 있다.
- 작성된 도형을 한번에 다 지울 수 있다.

# Kanban Link
https://www.notion.so/vanillacoding/7afbf5dbd9f54ee6b2bd92f10d693695

# Kanban List
- [x]  웹페이지상의 되돌리기 버튼을 생성한다
- [x]  생성된 버튼을 누르면 이전에 한 작업을 되돌릴 수 있도록 구현해야 한다.

# ETC
- 되돌리기 구현 외 전체그림을 지우는 clear기능 추가