### PR TITLE
[2022.10.26] 제스처로 도형 스케일 조절 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/src/components/Drawing/index.js
+++ b/src/components/Drawing/index.js
@@ -167,18 +167,20 @@ export default function Drawing() {
     onResize();
 
     const onDrawingEvent = (data) => {
-      drawLine(
-        [
-          data.startPosition[0] * canvas.width,
-          data.startPosition[1] * canvas.height,
-        ],
-        [
-          data.endPosition[0] * canvas.width,
-          data.endPosition[1] * canvas.height,
-        ],
-        data.color,
-        data.width,
-      );
+      if (data.startPosition) {
+        drawLine(
+          [
+            data.startPosition[0] * canvas.width,
+            data.startPosition[1] * canvas.height,
+          ],
+          [
+            data.endPosition[0] * canvas.width,
+            data.endPosition[1] * canvas.height,
+          ],
+          data.color,
+          data.width,
+        );
+      }
     };
 
     socketRef.current = io.connect(

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -25,6 +25,7 @@ export default function Figure() {
     let undoStore = [];
     let redoStore = [];
     let historyIndex = -1;
+    let scaleCount = 0;
 
     socketRef.current = io.connect(
       `http://${process.env.REACT_APP_PACKAGE_IPADDRESS}:${process.env.REACT_APP_PACKAGE_PORT}`,
@@ -32,17 +33,17 @@ export default function Figure() {
 
     socketRef.current.on("drawing", (data) => {
       if (Array.isArray(data)) {
-        // objects.current = data;
-        //
-        // visualizer();
+        objects.current = data;
+
+        visualizer();
       } else if (data === "triangle") {
         objects.current.push({
           x: 250,
           y: 300,
-          width: 100,
-          height: 50,
+          width: 50,
+          height: (Math.sqrt(3) / 2) * 50,
           color: "black",
-          type: "Triangle",
+          type: "triangle",
         });
 
         visualizer();
@@ -53,7 +54,7 @@ export default function Figure() {
           width: 50,
           height: 50,
           color: "black",
-          type: "Circle",
+          type: "circle",
         });
 
         visualizer();
@@ -64,8 +65,47 @@ export default function Figure() {
           width: 50,
           height: 50,
           color: "black",
-          type: "Square",
+          type: "square",
         });
+
+        visualizer();
+      } else if (data === "scaleUp") {
+        scaleCount++;
+        const selectedFigure = objects.current[objectActualIndex.current];
+
+        if (scaleCount === 2) {
+          if (selectedFigure.type === "triangle") {
+            selectedFigure.width += 1;
+            selectedFigure.height += Math.sqrt(3) / 2;
+          } else {
+            selectedFigure.width += 1;
+            selectedFigure.height += 1;
+          }
+
+          scaleCount = 0;
+        }
+
+        visualizer();
+      } else if (data === "scaleDown") {
+        const selectedFigure = objects.current[objectActualIndex.current];
+
+        if (selectedFigure.width < 11 || selectedFigure.height < 11) {
+          return;
+        }
+
+        scaleCount++;
+
+        if (scaleCount === 2) {
+          if (selectedFigure.type === "triangle") {
+            selectedFigure.width -= 1;
+            selectedFigure.height -= Math.sqrt(3) / 2;
+          } else {
+            selectedFigure.width -= 1;
+            selectedFigure.height -= 1;
+          }
+
+          scaleCount = 0;
+        }
 
         visualizer();
       }
@@ -84,7 +124,7 @@ export default function Figure() {
       context.beginPath();
 
       for (let i = 0; i < objects.current.length; i++) {
-        if (objects.current[i].type === "Square") {
+        if (objects.current[i].type === "square") {
           context.fillStyle = objects.current[i].color;
           context.fillRect(
             objects.current[i].x,
@@ -92,12 +132,12 @@ export default function Figure() {
             objects.current[i].width,
             objects.current[i].height,
           );
-        } else if (objects.current[i].type === "Circle") {
+        } else if (objects.current[i].type === "circle") {
           context.beginPath();
           context.arc(
             objects.current[i].x,
             objects.current[i].y,
-            objects.current[i].height,
+            objects.current[i].height / 2,
             0,
             2 * Math.PI,
           );
@@ -105,7 +145,7 @@ export default function Figure() {
           context.stroke();
           context.fillStyle = objects.current[i].color;
           context.fill();
-        } else if (objects.current[i].type === "Triangle") {
+        } else if (objects.current[i].type === "triangle") {
           context.beginPath();
           context.moveTo(objects.current[i].x, objects.current[i].y);
           context.lineTo(
@@ -276,7 +316,7 @@ export default function Figure() {
                     width: 50,
                     height: 50,
                     color: "black",
-                    type: "Square",
+                    type: "square",
                   });
                 }}
               >
@@ -290,7 +330,7 @@ export default function Figure() {
                     width: 50,
                     height: 50,
                     color: "black",
-                    type: "Circle",
+                    type: "circle",
                   });
                 }}
               >
@@ -301,10 +341,10 @@ export default function Figure() {
                   objects.current.push({
                     x: 250,
                     y: 300,
-                    width: 100,
-                    height: 50,
+                    width: 50,
+                    height: (Math.sqrt(3) / 2) * 50,
                     color: "black",
-                    type: "Triangle",
+                    type: "triangle",
                   });
                 }}
               >


### PR DESCRIPTION
# Topic
- 제스처로 도형 스케일 조절 기능 구현

# Detail
- 사용자가 제스처 드로잉모드에서 선택한 도형의 크기를 조절할 수 있는 기능 추가.
- react native gesture handler의 pinch 제스처 사용.

# Kanban Link
https://www.notion.so/vanillacoding/4c3a0faa643f4766a47c17c1d20e1b3a

# Kanban List
- [x]  터치패드에서 손가락을 이용하여 제스처를 인식해야 한다.
- [x]  제스처로 도형의 크기를 조절할 수 있어야한다.
- [x]  데이터를 package 파일을 거쳐 drawing 파일에서 적용해야한다.

# ETC
- 해당사항 없음