### PR TITLE
[2022.11.01] history, draw, visualizer 컴포넌트 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/src/pages/Drawing/index.js
+++ b/src/pages/Drawing/index.js
@@ -4,6 +4,9 @@ import io from "socket.io-client";
 import _ from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import { setLineColor, setLineWidth } from "../../store";
+import { undo, redo, clear } from "../../utils/history";
+import { drawLineWithEmit, drawLineWithoutEmit } from "../../utils/drawLine";
+import { drawingVisualizer } from "../../utils/drawingVisualizer";
 
 const Drawing = () => {
   const { lineColor, lineWidth } = useSelector(({ lineStyle }) => lineStyle);
@@ -52,121 +55,6 @@ const Drawing = () => {
       false,
     );
 
-    const undo = () => {
-      if (historyIndex.current < 0) {
-        window.alert("더이상 되돌아갈 작업이 없습니다.");
-      } else if (historyIndex.current === 0) {
-        const popUndoStore = _.cloneDeep(undoStore.current.pop());
-
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        redoStore.current.unshift(popUndoStore);
-
-        lineObjects.current.length = 0;
-        historyIndex.current = -1;
-
-        socketRef.current.emit("drawingHistory", {
-          lineObjects: lineObjects.current,
-          undoStore: undoStore.current,
-          redoStore: redoStore.current,
-          historyIndex: historyIndex.current,
-        });
-      } else {
-        const popUndoStore = _.cloneDeep(undoStore.current.pop());
-
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        redoStore.current.unshift(popUndoStore);
-
-        historyIndex.current -= 1;
-        lineObjects.current = _.cloneDeep(
-          undoStore.current[historyIndex.current],
-        );
-
-        visualizer(lineObjects.current);
-
-        socketRef.current.emit("drawingHistory", {
-          lineObjects: lineObjects.current,
-          undoStore: undoStore.current,
-          redoStore: redoStore.current,
-          historyIndex: historyIndex.current,
-        });
-      }
-    };
-
-    const redo = () => {
-      if (redoStore.current.length > 0) {
-        const shiftRedoStore = _.cloneDeep(redoStore.current.shift());
-
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        undoStore.current.push(shiftRedoStore);
-
-        historyIndex.current += 1;
-        lineObjects.current = _.cloneDeep(
-          undoStore.current[historyIndex.current],
-        );
-
-        visualizer(undoStore.current[historyIndex.current]);
-
-        socketRef.current.emit("drawingHistory", {
-          lineObjects: lineObjects.current,
-          undoStore: undoStore.current,
-          redoStore: redoStore.current,
-          historyIndex: historyIndex.current,
-        });
-      }
-    };
-
-    const clear = () => {
-      context.clearRect(0, 0, canvas.width, canvas.height);
-
-      undoStore.current.length = 0;
-      redoStore.current.length = 0;
-      historyIndex.current = -1;
-      lineObjects.current = [];
-
-      socketRef.current.emit("drawingHistory", {
-        lineObjects: [],
-        undoStore: [],
-        redoStore: [],
-        historyIndex: -1,
-      });
-    };
-
-    const drawLine = (startPosition, endPosition, color, width, emit) => {
-      context.beginPath();
-      context.moveTo(...startPosition);
-      context.lineTo(...endPosition);
-      context.strokeStyle = color;
-      context.lineWidth = width;
-      context.lineCap = "round";
-      context.stroke();
-      context.closePath();
-
-      if (!emit) {
-        return;
-      }
-
-      socketRef.current.emit("drawing", {
-        startPosition: [
-          startPosition[0] / canvas.width,
-          startPosition[1] / canvas.height,
-        ],
-        endPosition: [
-          endPosition[0] / canvas.width,
-          endPosition[1] / canvas.height,
-        ],
-        color,
-        width,
-      });
-    };
-
-    const visualizer = (path) => {
-      for (let i = 0; i < path.length; i++) {
-        for (let j = 0; j < path[i].length; j++) {
-          drawLine(...path[i][j]);
-        }
-      }
-    };
-
     const onMouseDown = (event) => {
       drawing = true;
       currentStyle.startPosition = [event.clientX, event.clientY];
@@ -177,12 +65,14 @@ const Drawing = () => {
         return;
       }
 
-      drawLine(
+      drawLineWithEmit(
+        context,
+        canvas,
+        socketRef,
         currentStyle.startPosition,
         [event.clientX, event.clientY],
         currentStyle.color,
         currentStyle.width,
-        true,
       );
 
       linePath.current.push([
@@ -190,7 +80,6 @@ const Drawing = () => {
         [event.clientX, event.clientY],
         currentStyle.color,
         currentStyle.width,
-        true,
       ]);
 
       currentStyle.startPosition = [event.clientX, event.clientY];
@@ -203,12 +92,14 @@ const Drawing = () => {
 
       drawing = false;
 
-      drawLine(
+      drawLineWithEmit(
+        context,
+        canvas,
+        socketRef,
         currentStyle.startPosition,
         [event.clientX, event.clientY],
         currentStyle.color,
         currentStyle.width,
-        true,
       );
 
       if (event.type !== "mouseout") {
@@ -234,9 +125,42 @@ const Drawing = () => {
     canvas.addEventListener("mouseout", onMouseUp, false);
     canvas.addEventListener("mousemove", onMouseMove, false);
 
-    clearElement.addEventListener("click", clear);
-    redoElement.addEventListener("click", redo);
-    undoElement.addEventListener("click", undo);
+    clearElement.addEventListener("click", () => {
+      clear(
+        "drawing",
+        context,
+        canvas,
+        socketRef,
+        undoStore,
+        redoStore,
+        historyIndex,
+        lineObjects,
+      );
+    });
+    redoElement.addEventListener("click", () => {
+      redo(
+        "drawing",
+        context,
+        canvas,
+        socketRef,
+        undoStore,
+        redoStore,
+        historyIndex,
+        lineObjects,
+      );
+    });
+    undoElement.addEventListener("click", () => {
+      undo(
+        "drawing",
+        context,
+        canvas,
+        socketRef,
+        undoStore,
+        redoStore,
+        historyIndex,
+        lineObjects,
+      );
+    });
 
     const onResize = () => {
       canvas.width = 2560;
@@ -248,7 +172,8 @@ const Drawing = () => {
 
     const onDrawingEvent = (data) => {
       if (data.startPosition) {
-        drawLine(
+        drawLineWithoutEmit(
+          context,
           [
             data.startPosition[0] * canvas.width,
             data.startPosition[1] * canvas.height,
@@ -280,7 +205,7 @@ const Drawing = () => {
       historyIndex.current = data.historyIndex;
 
       context.clearRect(0, 0, canvas.width, canvas.height);
-      visualizer([...data.lineObjects]);
+      drawingVisualizer(context, [...data.lineObjects]);
     });
 
     return () => {

--- a/src/utils/drawLine.js
+++ b/src/utils/drawLine.js
@@ -1,0 +1,48 @@
+export const drawLineWithEmit = (
+  context,
+  canvas,
+  socket,
+  startPosition,
+  endPosition,
+  color,
+  width,
+) => {
+  context.beginPath();
+  context.moveTo(...startPosition);
+  context.lineTo(...endPosition);
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "round";
+  context.stroke();
+  context.closePath();
+
+  socket.current.emit("drawing", {
+    startPosition: [
+      startPosition[0] / canvas.width,
+      startPosition[1] / canvas.height,
+    ],
+    endPosition: [
+      endPosition[0] / canvas.width,
+      endPosition[1] / canvas.height,
+    ],
+    color,
+    width,
+  });
+};
+
+export const drawLineWithoutEmit = (
+  context,
+  startPosition,
+  endPosition,
+  color,
+  width,
+) => {
+  context.beginPath();
+  context.moveTo(...startPosition);
+  context.lineTo(...endPosition);
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "round";
+  context.stroke();
+  context.closePath();
+};

--- a/src/utils/drawingVisualizer.js
+++ b/src/utils/drawingVisualizer.js
@@ -1,0 +1,9 @@
+import { drawLineWithoutEmit } from "./drawLine";
+
+export const drawingVisualizer = (context, path) => {
+  for (let i = 0; i < path.length; i++) {
+    for (let j = 0; j < path[i].length; j++) {
+      drawLineWithoutEmit(context, ...path[i][j]);
+    }
+  }
+};

--- a/src/utils/figureVisualizer.js
+++ b/src/utils/figureVisualizer.js
@@ -1,0 +1,42 @@
+export const figureVisualizer = (context, figures) => {
+  context.clearRect(0, 0, window.innerWidth, window.innerHeight);
+  context.beginPath();
+
+  for (let i = 0; i < figures.length; i++) {
+    if (figures[i].type === "square") {
+      context.fillStyle = figures[i].color;
+      context.fillRect(
+        figures[i].x,
+        figures[i].y,
+        figures[i].width,
+        figures[i].height,
+      );
+    } else if (figures[i].type === "circle") {
+      context.beginPath();
+      context.arc(
+        figures[i].x,
+        figures[i].y,
+        figures[i].height / 2,
+        0,
+        2 * Math.PI,
+      );
+
+      context.stroke();
+      context.fillStyle = figures[i].color;
+      context.fill();
+    } else if (figures[i].type === "triangle") {
+      context.beginPath();
+      context.moveTo(figures[i].x, figures[i].y);
+      context.lineTo(
+        figures[i].x + figures[i].width / 2,
+        figures[i].y - figures[i].height,
+      );
+
+      context.lineTo(figures[i].x + figures[i].width, figures[i].y);
+
+      context.closePath();
+      context.fillStyle = figures[i].color;
+      context.fill();
+    }
+  }
+};

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,150 @@
+import _ from "lodash";
+import { drawingVisualizer } from "./drawingVisualizer";
+import { figureVisualizer } from "./figureVisualizer";
+
+export const undo = (
+  type,
+  context,
+  canvas,
+  socket,
+  undoStore,
+  redoStore,
+  historyIndex,
+  objects,
+) => {
+  if (historyIndex.current < 0) {
+    window.alert("더이상 되돌아갈 작업이 없습니다.");
+  } else if (historyIndex.current === 0) {
+    const popUndoStore = _.cloneDeep(undoStore.current.pop());
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    redoStore.current.unshift(popUndoStore);
+
+    objects.current.length = 0;
+    historyIndex.current = -1;
+
+    if (type === "drawing") {
+      socket.current.emit("drawingHistory", {
+        lineObjects: objects.current,
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    } else {
+      socket.current.emit("figureHistory", {
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    }
+  } else {
+    const popUndoStore = _.cloneDeep(undoStore.current.pop());
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    redoStore.current.unshift(popUndoStore);
+
+    historyIndex.current -= 1;
+    objects.current = _.cloneDeep(undoStore.current[historyIndex.current]);
+
+    if (type === "drawing") {
+      drawingVisualizer(context, objects.current);
+
+      socket.current.emit("drawingHistory", {
+        lineObjects: objects.current,
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    } else {
+      figureVisualizer(context, objects.current);
+
+      socket.current.emit("figureHistory", {
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    }
+  }
+};
+
+export const redo = (
+  type,
+  context,
+  canvas,
+  socket,
+  undoStore,
+  redoStore,
+  historyIndex,
+  objects,
+) => {
+  if (redoStore.current.length > 0) {
+    const shiftRedoStore = _.cloneDeep(redoStore.current.shift());
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    undoStore.current.push(shiftRedoStore);
+
+    historyIndex.current += 1;
+
+    const lastUndoStoreData = _.cloneDeep(
+      undoStore.current[historyIndex.current],
+    );
+
+    objects.current = lastUndoStoreData;
+
+    figureVisualizer(context, objects.current);
+
+    if (type === "drawing") {
+      drawingVisualizer(context, objects.current);
+
+      socket.current.emit("drawingHistory", {
+        lineObjects: objects.current,
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    } else {
+      figureVisualizer(context, objects.current);
+
+      socket.current.emit("figureHistory", {
+        undoStore: undoStore.current,
+        redoStore: redoStore.current,
+        historyIndex: historyIndex.current,
+      });
+    }
+  }
+};
+
+export const clear = (
+  type,
+  context,
+  canvas,
+  socket,
+  undoStore,
+  redoStore,
+  historyIndex,
+  objects,
+) => {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+
+  undoStore.current.length = 0;
+  redoStore.current.length = 0;
+  objects.current.length = 0;
+  historyIndex.current = -1;
+
+  if (type === "drawing") {
+    socket.current.emit("drawingHistory", {
+      lineObjects: objects.current,
+      undoStore: undoStore.current,
+      redoStore: redoStore.current,
+      historyIndex: historyIndex.current,
+    });
+  } else {
+    figureVisualizer(context, objects.current);
+
+    socket.current.emit("figureHistory", {
+      undoStore: undoStore.current,
+      redoStore: redoStore.current,
+      historyIndex: historyIndex.current,
+    });
+  }
+};


### PR DESCRIPTION
# Topic
- history, draw, visualizer 컴포넌트 분리

# Detail
- Draw, Figure Pages 분리
- Draw와 Figure에서 사용하던 history, draw, visualizer 함수를 컴포넌트로 분리

# Kanban Link
해당사항 없음

# Kanban List
해당사항 없음

# ETC
- 해당사항 없음