### PR TITLE
[2022.11.02] 컴포넌트 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.5.1",
+  "version": "1.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-trackpad-gesture-drawing",
-      "version": "1.5.1",
+      "version": "1.5.4",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.6",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-trackpad-gesture-drawing",
-      "version": "1.4.2",
+      "version": "1.5.1",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.6",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-trackpad-gesture-drawing",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.6",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.5.1",
+  "version": "1.5.4",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-gesture-drawing",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/src/components/AddFigureButton/index.js
+++ b/src/components/AddFigureButton/index.js
@@ -1,0 +1,59 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+import NEW_FIGURES from "../../constants/NEW_FIGURES";
+
+const AddFigureButton = ({ inputUndo, type }, ref) => {
+  const { objects } = ref;
+  const figureType =
+    type === "square"
+      ? NEW_FIGURES.SQUARE
+      : type === "circle"
+      ? NEW_FIGURES.CIRCLE
+      : NEW_FIGURES.TRIANGLE;
+
+  return (
+    <AddFigureButtonContainer>
+      <button
+        onClick={() => {
+          objects.current.push({ ...figureType });
+
+          inputUndo(objects.current);
+        }}
+      >
+        <span className="material-symbols-outlined">
+          {type === "triangle" ? "change_history" : type}
+        </span>
+      </button>
+    </AddFigureButtonContainer>
+  );
+};
+
+const AddFigureButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 2vh;
+
+  button {
+    margin: 0 0.5vmin;
+    padding: 1vmin 1.4vmin;
+    color: #777;
+    font-size: 1.5vmin;
+    border: none;
+    border-radius: 1.5vmin;
+    user-select: none;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    :hover {
+      background-color: hsl(0, 0%, 80%);
+    }
+
+    :active {
+      background-color: hsl(0, 0%, 60%);
+    }
+  }
+`;
+
+export default forwardRef(AddFigureButton);

--- a/src/components/DrawingColorTool/index.js
+++ b/src/components/DrawingColorTool/index.js
@@ -33,4 +33,4 @@ const DrawingColorToolContainer = styled.div`
   margin-bottom: 1vh;
 `;
 
-export default forwardRef(DrawingColorTool);
+export default DrawingColorTool;

--- a/src/components/DrawingColorTool/index.js
+++ b/src/components/DrawingColorTool/index.js
@@ -1,0 +1,36 @@
+import React, { forwardRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import { setLineColor } from "../../redux/reducers/lineStyle";
+
+const DrawingColorTool = () => {
+  const { lineColor } = useSelector(({ lineStyle }) => lineStyle);
+
+  const dispatch = useDispatch();
+
+  return (
+    <DrawingColorToolContainer>
+      <div className="drawing-tool">
+        <p>선 색상변경</p>
+        <input
+          type="color"
+          className="colorChange"
+          onChange={(event) => {
+            dispatch(setLineColor(event.target.value));
+          }}
+        />
+        <h5>{lineColor}</h5>
+      </div>
+    </DrawingColorToolContainer>
+  );
+};
+
+const DrawingColorToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 1vh;
+`;
+
+export default forwardRef(DrawingColorTool);

--- a/src/components/DrawingColorTool/index.js
+++ b/src/components/DrawingColorTool/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { setLineColor } from "../../redux/reducers/lineStyle";

--- a/src/components/DrawingHistoryButton/index.js
+++ b/src/components/DrawingHistoryButton/index.js
@@ -35,4 +35,4 @@ const DrawingHistoryButtonContainer = styled.div`
   }
 `;
 
-export default forwardRef(DrawingHistoryButton);
+export default DrawingHistoryButton;

--- a/src/components/DrawingHistoryButton/index.js
+++ b/src/components/DrawingHistoryButton/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 import styled from "styled-components";
 
 const DrawingHistoryButton = () => {

--- a/src/components/DrawingHistoryButton/index.js
+++ b/src/components/DrawingHistoryButton/index.js
@@ -1,0 +1,38 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+
+const DrawingHistoryButton = () => {
+  return (
+    <DrawingHistoryButtonContainer>
+      <h4>히스토리</h4>
+      <div>
+        <button className="drawingUndoButton drawing-historyButton">
+          undo
+        </button>
+        <button className="drawingRedoButton drawing-historyButton">
+          redo
+        </button>
+        <button className="drawingClearButton drawing-historyButton">
+          clear
+        </button>
+      </div>
+    </DrawingHistoryButtonContainer>
+  );
+};
+
+const DrawingHistoryButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 1vh;
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1vh;
+  }
+`;
+
+export default forwardRef(DrawingHistoryButton);

--- a/src/components/DrawingWidthTool/index.js
+++ b/src/components/DrawingWidthTool/index.js
@@ -1,0 +1,39 @@
+import React, { forwardRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import { setLineWidth } from "../../redux/reducers/lineStyle";
+
+const DrawingWidthTool = () => {
+  const { lineWidth } = useSelector(({ lineStyle }) => lineStyle);
+
+  const dispatch = useDispatch();
+
+  return (
+    <DrawingWidthToolContainer>
+      <div className="drawing-tool">
+        <p>선 굵기</p>
+        <input
+          type="range"
+          min="1"
+          max="200"
+          defaultValue="5"
+          className="widthChange"
+          onChange={(event) => {
+            dispatch(setLineWidth(event.target.value));
+          }}
+        />
+        <h5>{lineWidth}</h5>
+      </div>
+    </DrawingWidthToolContainer>
+  );
+};
+
+const DrawingWidthToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 1vh;
+`;
+
+export default forwardRef(DrawingWidthTool);

--- a/src/components/DrawingWidthTool/index.js
+++ b/src/components/DrawingWidthTool/index.js
@@ -36,4 +36,4 @@ const DrawingWidthToolContainer = styled.div`
   margin-bottom: 1vh;
 `;
 
-export default forwardRef(DrawingWidthTool);
+export default DrawingWidthTool;

--- a/src/components/DrawingWidthTool/index.js
+++ b/src/components/DrawingWidthTool/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { setLineWidth } from "../../redux/reducers/lineStyle";

--- a/src/components/FigureColorTool/index.js
+++ b/src/components/FigureColorTool/index.js
@@ -1,0 +1,32 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+
+const FigureColorTool = (props, ref) => {
+  const { objects, objectActualIndex } = ref;
+
+  return (
+    <FigureColorToolContainer>
+      <h4>색상</h4>
+      <input
+        type="color"
+        onChange={(event) => {
+          objects.current[objectActualIndex.current].color = event.target.value;
+        }}
+      />
+    </FigureColorToolContainer>
+  );
+};
+
+const FigureColorToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 2vh;
+
+  input {
+    width: 10vmin;
+  }
+`;
+
+export default forwardRef(FigureColorTool);

--- a/src/components/FigureHeightTool/index.js
+++ b/src/components/FigureHeightTool/index.js
@@ -1,0 +1,40 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+
+const FigureHeightTool = (props, ref) => {
+  const { objects, objectActualIndex } = ref;
+
+  return (
+    <FigureHeightToolContainer>
+      <h4>높이</h4>
+      <input
+        onChange={(event) => {
+          const selectedFigure = objects.current[objectActualIndex.current];
+
+          if (selectedFigure.type === "circle") {
+            selectedFigure.height = event.target.value;
+            selectedFigure.width = event.target.value;
+          } else if (selectedFigure.type === "triangle") {
+            selectedFigure.height = (Math.sqrt(3) / 2) * event.target.value;
+          } else {
+            selectedFigure.height = event.target.value;
+          }
+        }}
+      />
+    </FigureHeightToolContainer>
+  );
+};
+
+const FigureHeightToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 2vh;
+
+  input {
+    width: 10vmin;
+  }
+`;
+
+export default forwardRef(FigureHeightTool);

--- a/src/components/FigureHistoryButton/index.js
+++ b/src/components/FigureHistoryButton/index.js
@@ -31,4 +31,4 @@ const FigureHistoryButtonContainer = styled.div`
   }
 `;
 
-export default forwardRef(FigureHistoryButton);
+export default FigureHistoryButton;

--- a/src/components/FigureHistoryButton/index.js
+++ b/src/components/FigureHistoryButton/index.js
@@ -1,0 +1,34 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+
+const FigureHistoryButton = () => {
+  return (
+    <FigureHistoryButtonContainer>
+      <h4>히스토리</h4>
+      <div>
+        <button className="figureUndoButton figure-historyButton">undo</button>
+        <button className="figureRedoButton figure-historyButton">redo</button>
+        <button className="figureClearButton figure-historyButton">
+          clear
+        </button>
+      </div>
+    </FigureHistoryButtonContainer>
+  );
+};
+
+const FigureHistoryButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 1vh;
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1vh;
+  }
+`;
+
+export default forwardRef(FigureHistoryButton);

--- a/src/components/FigureHistoryButton/index.js
+++ b/src/components/FigureHistoryButton/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 import styled from "styled-components";
 
 const FigureHistoryButton = () => {

--- a/src/components/FigureWidthTool/index.js
+++ b/src/components/FigureWidthTool/index.js
@@ -1,0 +1,40 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+
+const FigureWidthTool = (props, ref) => {
+  const { objects, objectActualIndex } = ref;
+
+  return (
+    <FigureWidthToolContainer>
+      <h4>너비</h4>
+      <input
+        onChange={(event) => {
+          const selectedFigure = objects.current[objectActualIndex.current];
+
+          if (selectedFigure.type === "circle") {
+            selectedFigure.height = event.target.value;
+            selectedFigure.width = event.target.value;
+          } else if (selectedFigure.type === "triangle") {
+            selectedFigure.width = (Math.sqrt(3) / 2) * event.target.value;
+          } else {
+            selectedFigure.width = event.target.value;
+          }
+        }}
+      />
+    </FigureWidthToolContainer>
+  );
+};
+
+const FigureWidthToolContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 2vh;
+
+  input {
+    width: 10vmin;
+  }
+`;
+
+export default forwardRef(FigureWidthTool);

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -47,9 +47,9 @@ const SideBar = () => {
         }}
       >
         {isFoldSideBar ? (
-          <span className="material-symbols-outlined">navigate_before</span>
-        ) : (
           <span className="material-symbols-outlined">navigate_next</span>
+        ) : (
+          <span className="material-symbols-outlined">navigate_before</span>
         )}
       </div>
       {tools.map((value, index) => {

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -66,7 +66,7 @@ const SideBarContainer = styled.div`
   align-items: center;
   flex-direction: column;
   height: 100vh;
-  width: 15vw;
+  width: 200px;
   background-color: #f5efe6;
   box-shadow: 5px 0px 10px hsla(0, 0%, 10%, 0.2);
   transition: all 0.4s ease-in-out;
@@ -113,7 +113,7 @@ const SideBarContainer = styled.div`
     height: 4vmin;
     width: 4vmin;
     border-radius: 2vmin;
-    transform: translateY(3vh) translateX(7.5vw);
+    transform: translateY(3vh) translateX(100px);
     box-shadow: 2px 0px 5px hsla(0, 0%, 10%, 0.2);
     transition: all 0.2s ease-in-out;
     user-select: none;

--- a/src/components/SidebarTool/index.js
+++ b/src/components/SidebarTool/index.js
@@ -6,6 +6,7 @@ import capitalizeFirstLetter from "../../utils/capitalizeFirstLetter";
 
 const SideBarTool = ({ tool }) => {
   const { isFoldSideBar } = useSelector(({ isFoldSideBar }) => isFoldSideBar);
+
   const dispatch = useDispatch();
 
   return (

--- a/src/components/SidebarTool/index.js
+++ b/src/components/SidebarTool/index.js
@@ -18,7 +18,7 @@ const SideBarTool = ({ tool }) => {
       <span
         className="material-symbols-outlined sidebar-icon"
         style={{
-          transform: isFoldSideBar ? ["translateX(10vmin)"] : ["translateX(0)"],
+          transform: isFoldSideBar ? ["translateX(75px)"] : ["translateX(0)"],
         }}
       >
         {tool.icon}
@@ -40,7 +40,7 @@ const SideBarToolContainer = styled.div`
   align-items: center;
   margin-bottom: 5vh;
   padding: 2vh 0;
-  width: 13vw;
+  width: 200px;
   border-radius: 1vmin;
   user-select: none;
   cursor: pointer;
@@ -49,8 +49,8 @@ const SideBarToolContainer = styled.div`
   .sidebar-icon {
     font-weight: bold;
     user-select: none;
-    margin-left: 2.2vw;
-    margin-right: 1.5vw;
+    margin-left: 40px;
+    margin-right: 20px;
     transition: all 0.4s ease-in-out;
   }
 

--- a/src/constants/NEW_FIGURES.js
+++ b/src/constants/NEW_FIGURES.js
@@ -1,0 +1,26 @@
+export default {
+  SQUARE: {
+    x: 400,
+    y: 400,
+    width: 50,
+    height: 50,
+    color: "black",
+    type: "square",
+  },
+  CIRCLE: {
+    x: 400,
+    y: 400,
+    width: 50,
+    height: 50,
+    color: "black",
+    type: "circle",
+  },
+  TRIANGLE: {
+    x: 400,
+    y: 400,
+    width: 50,
+    height: (Math.sqrt(3) / 2) * 50,
+    color: "black",
+    type: "triangle",
+  },
+};

--- a/src/pages/Drawing/index.js
+++ b/src/pages/Drawing/index.js
@@ -7,6 +7,9 @@ import { setLineColor, setLineWidth } from "../../redux/reducers/lineStyle";
 import { undo, redo, clear } from "../../utils/history";
 import { drawLineWithEmit, drawLineWithoutEmit } from "../../utils/drawLine";
 import { drawingVisualizer } from "../../utils/drawingVisualizer";
+import DrawingColorTool from "../../components/DrawingColorTool";
+import DrawingWidthTool from "../../components/DrawingWidthTool";
+import DrawingHistoryButton from "../../components/DrawingHistoryButton";
 
 const Drawing = () => {
   const { lineColor, lineWidth } = useSelector(({ lineStyle }) => lineStyle);
@@ -238,43 +241,10 @@ const Drawing = () => {
         >
           <h1>Drawing</h1>
           <div className="drawing-toolBox">
-            <div className="drawing-tool">
-              <p>선 색상변경</p>
-              <input
-                type="color"
-                className="colorChange"
-                onChange={(event) => {
-                  dispatch(setLineColor(event.target.value));
-                }}
-              />
-              <h5>{lineColor}</h5>
-            </div>
-            <div className="drawing-tool">
-              <p>선 굵기</p>
-              <input
-                type="range"
-                min="1"
-                max="200"
-                defaultValue="5"
-                className="widthChange"
-                onChange={(event) => {
-                  dispatch(setLineWidth(event.target.value));
-                }}
-              />
-              <h5>{lineWidth}</h5>
-            </div>
+            <DrawingColorTool />
+            <DrawingWidthTool />
           </div>
-          <div>
-            <button className="drawingUndoButton drawing-historyButton">
-              undo
-            </button>
-            <button className="drawingRedoButton drawing-historyButton">
-              redo
-            </button>
-            <button className="drawingClearButton drawing-historyButton">
-              clear
-            </button>
-          </div>
+          <DrawingHistoryButton />
           <div
             onClick={() => {
               setIsModalShow(false);

--- a/src/pages/Drawing/index.js
+++ b/src/pages/Drawing/index.js
@@ -2,8 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import io from "socket.io-client";
 import _ from "lodash";
-import { useDispatch, useSelector } from "react-redux";
-import { setLineColor, setLineWidth } from "../../redux/reducers/lineStyle";
+import { useSelector } from "react-redux";
 import { undo, redo, clear } from "../../utils/history";
 import { drawLineWithEmit, drawLineWithoutEmit } from "../../utils/drawLine";
 import { drawingVisualizer } from "../../utils/drawingVisualizer";
@@ -16,8 +15,6 @@ const Drawing = () => {
   const { selectedTool } = useSelector(({ selectedTool }) => selectedTool);
 
   const [isModalShow, setIsModalShow] = useState(false);
-
-  const dispatch = useDispatch();
 
   const canvasRef = useRef(null);
   const socketRef = useRef(null);

--- a/src/pages/Figure/index.js
+++ b/src/pages/Figure/index.js
@@ -5,6 +5,12 @@ import _ from "lodash";
 import { useSelector } from "react-redux";
 import { undo, redo, clear } from "../../utils/history";
 import { figureVisualizer } from "../../utils/figureVisualizer";
+import NEW_FIGURES from "../../constants/NEW_FIGURES";
+import FigureTool from "../../components/FigureHeightTool";
+import FigureWidthTool from "../../components/FigureWidthTool";
+import FigureColorTool from "../../components/FigureColorTool";
+import AddFigureButton from "../../components/AddFigureButton";
+import FigureHistoryButton from "../../components/FigureHistoryButton";
 
 const Figure = () => {
   const { selectedTool } = useSelector(({ selectedTool }) => selectedTool);
@@ -21,33 +27,6 @@ const Figure = () => {
   const undoStore = useRef([]);
   const redoStore = useRef([]);
   const historyIndex = useRef(-1);
-
-  const newFigures = {
-    square: {
-      x: 400,
-      y: 400,
-      width: 50,
-      height: 50,
-      color: "black",
-      type: "square",
-    },
-    circle: {
-      x: 400,
-      y: 400,
-      width: 50,
-      height: 50,
-      color: "black",
-      type: "circle",
-    },
-    triangle: {
-      x: 400,
-      y: 400,
-      width: 50,
-      height: (Math.sqrt(3) / 2) * 50,
-      color: "black",
-      type: "triangle",
-    },
-  };
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -84,15 +63,15 @@ const Figure = () => {
 
     socketPackRef.current.on("drawingGesture", (data) => {
       if (data === "triangle") {
-        objects.current.push(newFigures.triangle);
+        objects.current.push(NEW_FIGURES.TRIANGLE);
 
         figureVisualizer(context, objects.current);
       } else if (data === "circle") {
-        objects.current.push(newFigures.circle);
+        objects.current.push(NEW_FIGURES.CIRCLE);
 
         figureVisualizer(context, objects.current);
       } else if (data === "square") {
-        objects.current.push(newFigures.square);
+        objects.current.push(NEW_FIGURES.SQUARE);
 
         figureVisualizer(context, objects.current);
       } else if (data === "scaleUp") {
@@ -323,104 +302,27 @@ const Figure = () => {
           <h1>Figure</h1>
           <div className="figure-toolBox">
             <div className="controlBox">
-              <div>
-                <h4>높이</h4>
-                <input
-                  onChange={(event) => {
-                    const selectedFigure =
-                      objects.current[objectActualIndex.current];
-
-                    if (selectedFigure.type === "circle") {
-                      selectedFigure.height = event.target.value;
-                      selectedFigure.width = event.target.value;
-                    } else if (selectedFigure.type === "triangle") {
-                      selectedFigure.height =
-                        (Math.sqrt(3) / 2) * event.target.value;
-                    } else {
-                      selectedFigure.height = event.target.value;
-                    }
-                  }}
-                />
-              </div>
-              <div>
-                <h4>폭</h4>
-                <input
-                  onChange={(event) => {
-                    const selectedFigure =
-                      objects.current[objectActualIndex.current];
-
-                    if (selectedFigure.type === "circle") {
-                      selectedFigure.height = event.target.value;
-                      selectedFigure.width = event.target.value;
-                    } else if (selectedFigure.type === "triangle") {
-                      selectedFigure.width =
-                        (Math.sqrt(3) / 2) * event.target.value;
-                    } else {
-                      selectedFigure.width = event.target.value;
-                    }
-                  }}
-                />
-              </div>
-              <div>
-                <h4>색상</h4>
-                <input
-                  type="color"
-                  onChange={(event) => {
-                    objects.current[objectActualIndex.current].color =
-                      event.target.value;
-                  }}
-                />
-              </div>
+              <FigureTool ref={{ objects, objectActualIndex }} />
+              <FigureWidthTool ref={{ objects, objectActualIndex }} />
+              <FigureColorTool ref={{ objects, objectActualIndex }} />
             </div>
           </div>
           <div className="buttonBox">
             <h4>도형 추가</h4>
             <div>
-              <button
-                onClick={() => {
-                  objects.current.push(newFigures.square);
-
-                  inputUndo(objects.current);
-                }}
-              >
-                <span className="material-symbols-outlined">square</span>
-              </button>
-              <button
-                onClick={() => {
-                  objects.current.push(newFigures.circle);
-
-                  inputUndo(objects.current);
-                }}
-              >
-                <span className="material-symbols-outlined">circle</span>
-              </button>
-              <button
-                onClick={() => {
-                  objects.current.push(newFigures.triangle);
-
-                  inputUndo(objects.current);
-                }}
-              >
-                <span className="material-symbols-outlined">
-                  change_history
-                </span>
-              </button>
+              {["square", "circle", "triangle"].map((value, index) => {
+                return (
+                  <AddFigureButton
+                    inputUndo={inputUndo}
+                    type={value}
+                    ref={{ objects }}
+                    key={index}
+                  />
+                );
+              })}
             </div>
           </div>
-          <div className="figure-historyBox">
-            <h4>히스토리</h4>
-            <div>
-              <button className="figureUndoButton figure-historyButton">
-                undo
-              </button>
-              <button className="figureRedoButton figure-historyButton">
-                redo
-              </button>
-              <button className="figureClearButton figure-historyButton">
-                clear
-              </button>
-            </div>
-          </div>
+          <FigureHistoryButton />
           <div
             onClick={() => {
               setIsModalShow(false);
@@ -585,24 +487,10 @@ const FigureContainer = styled.div`
     flex-direction: column;
     margin-top: 2vh;
 
-    button {
-      margin: 0 0.5vmin;
-      padding: 1vmin 1.4vmin;
-      color: #777;
-      font-size: 1.5vmin;
-      border: none;
-      border-radius: 1.5vmin;
-      user-select: none;
-      cursor: pointer;
-      transition: all 0.2s ease-in-out;
-
-      :hover {
-        background-color: hsl(0, 0%, 80%);
-      }
-
-      :active {
-        background-color: hsl(0, 0%, 60%);
-      }
+    div {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   }
 


### PR DESCRIPTION
# Topic
- 컴포넌트 분리

# Detail
- 각 페이지에서 사용한 useref를 forwardRef를 사용해서 작은 컴포넌트로 분리시킴.
- 웹사이트의 크기가 변경되어도 UI의 변형이 되지 않도록 디자인 수정

# Kanban Link
- 해당사항 없음

# Kanban List
- 해당사항 없음

# ETC
- 해당사항 없음